### PR TITLE
backport: Added fixes for Spectre (CVE-2017-5715) vulnerability

### DIFF
--- a/qemu-kvm.spec
+++ b/qemu-kvm.spec
@@ -52,7 +52,7 @@
 
 #Versions of various parts:
 
-%define buildid .CROC1
+%define buildid .CROC2
 %define pkgname qemu-kvm
 %define rhel_suffix -rhel
 %define rhev_suffix -rhev
@@ -1325,6 +1325,12 @@ Patch614: kvm-block-iscsi-avoid-potential-overflow-of-acb-task-cdb.patch
 # CROC backports
 # Backport of bz#1392876
 Patch9000: 9000-Workaround-rhel6-ctrl_guest_offloads-machine-type-mi.patch
+# Backport of CVE-2017-5715 fixes
+Patch9001: 9001-target-i386-add-support-for-SPEC_CTRL-MSR.patch
+# Backport of https://github.com/qemu/qemu/commit/95ea69fb46.patch
+Patch9002: 9002-x86-add-AVX512_4VNNIW-and-AVX512_4FMAPS-features.patch
+# Backport of CVE-2017-5715 fixes
+Patch9003: 9003-target-i386-cpu-add-new-CPUID-bits-for-indirect-bran.patch
 
 BuildRequires: zlib-devel
 BuildRequires: SDL-devel
@@ -2157,6 +2163,9 @@ ApplyOptionalPatch()
 
 # CROC backports
 %patch9000 -p1
+%patch9001 -p1
+%patch9002 -p1
+%patch9003 -p1
 
 ApplyOptionalPatch qemu-kvm-test.patch
 
@@ -2572,6 +2581,11 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 %{_libdir}/pkgconfig/libcacard.pc
 
 %changelog
+* Mon Jan 08 2018 Mikhail Ushanov <MiUshanov@croc.ru> - ev-2.3.0-31.0.el7_2.21.CROC2
+- 9001-target-i386-add-support-for-SPEC_CTRL-MSR.patch
+- 9002-x86-add-AVX512_4VNNIW-and-AVX512_4FMAPS-features.patch
+- 9003-target-i386-cpu-add-new-CPUID-bits-for-indirect-bran.patch
+
 * Fri Sep 01 2017 Mikhail Ushanov <MiUshanov@croc.ru> - ev-2.3.0-31.0.el7_2.21.CROC1
 - 9000-Workaround-rhel6-ctrl_guest_offloads-machine-type-mi.patch
 

--- a/target-i386/cpu.c
+++ b/target-i386/cpu.c
@@ -266,7 +266,7 @@ static const char *cpuid_7_0_edx_feature_name[] = {
     NULL, NULL, "avx512-4vnniw", "avx512-4fmaps", NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, "spec_ctrl", "stibp", NULL, "arch-facilities", NULL, NULL,
 };
 
 static const char *cpuid_apm_edx_feature_name[] = {
@@ -274,6 +274,17 @@ static const char *cpuid_apm_edx_feature_name[] = {
     NULL, NULL, NULL, NULL,
     "invtsc", NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+};
+
+static const char *cpuid_80000008_ebx_feature_name[] = {
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL,
+    "ibpb_support", NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
@@ -415,6 +426,13 @@ static FeatureWordInfo feature_word_info[FEATURE_WORDS] = {
         .cpuid_reg = R_EDX,
         .tcg_features = TCG_APM_FEATURES,
         .unmigratable_flags = CPUID_APM_INVTSC,
+    },
+    [FEAT_8000_0008_EBX] = {
+        .feat_names = cpuid_80000008_ebx_feature_name,
+        .cpuid_eax = 0x80000008,
+        .cpuid_reg = R_EBX,
+        .tcg_features = 0,
+        .unmigratable_flags = 0,
     },
     [FEAT_XSAVE] = {
         .feat_names = cpuid_xsave_feature_name,
@@ -2624,7 +2642,7 @@ void cpu_x86_cpuid(CPUX86State *env, uint32_t index, uint32_t count,
                 *eax = 0x00000020; /* 32 bits physical */
             }
         }
-        *ebx = 0;
+        *ebx = env->features[FEAT_8000_0008_EBX];
         *ecx = 0;
         *edx = 0;
         if (cs->nr_cores * cs->nr_threads > 1) {

--- a/target-i386/cpu.c
+++ b/target-i386/cpu.c
@@ -262,6 +262,13 @@ static const char *cpuid_7_0_ebx_feature_name[] = {
     NULL, NULL, "avx512pf", "avx512er", "avx512cd", NULL, NULL, NULL,
 };
 
+static const char *cpuid_7_0_edx_feature_name[] = {
+    NULL, NULL, "avx512-4vnniw", "avx512-4fmaps", NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+};
+
 static const char *cpuid_apm_edx_feature_name[] = {
     NULL, NULL, NULL, NULL,
     NULL, NULL, NULL, NULL,
@@ -338,6 +345,7 @@ static const char *cpuid_xsave_feature_name[] = {
           CPUID_7_0_EBX_FSGSBASE, CPUID_7_0_EBX_HLE, CPUID_7_0_EBX_AVX2,
           CPUID_7_0_EBX_ERMS, CPUID_7_0_EBX_INVPCID, CPUID_7_0_EBX_RTM,
           CPUID_7_0_EBX_RDSEED */
+#define TCG_7_0_EDX_FEATURES 0
 #define TCG_APM_FEATURES 0
 
 
@@ -393,6 +401,13 @@ static FeatureWordInfo feature_word_info[FEATURE_WORDS] = {
         .cpuid_needs_ecx = true, .cpuid_ecx = 0,
         .cpuid_reg = R_EBX,
         .tcg_features = TCG_7_0_EBX_FEATURES,
+    },
+    [FEAT_7_0_EDX] = {
+        .feat_names = cpuid_7_0_edx_feature_name,
+        .cpuid_eax = 7,
+        .cpuid_needs_ecx = true, .cpuid_ecx = 0,
+        .cpuid_reg = R_EDX,
+        .tcg_features = TCG_7_0_EDX_FEATURES,
     },
     [FEAT_8000_0007_EDX] = {
         .feat_names = cpuid_apm_edx_feature_name,
@@ -2440,7 +2455,7 @@ void cpu_x86_cpuid(CPUX86State *env, uint32_t index, uint32_t count,
             *eax = 0; /* Maximum ECX value for sub-leaves */
             *ebx = env->features[FEAT_7_0_EBX]; /* Feature flags */
             *ecx = 0; /* Reserved */
-            *edx = 0; /* Reserved */
+            *edx = env->features[FEAT_7_0_EDX]; /* Feature flags */
         } else {
             *eax = 0;
             *ebx = 0;

--- a/target-i386/cpu.h
+++ b/target-i386/cpu.h
@@ -308,6 +308,7 @@
 #define MSR_IA32_APICBASE_BASE          (0xfffff<<12)
 #define MSR_IA32_FEATURE_CONTROL        0x0000003a
 #define MSR_TSC_ADJUST                  0x0000003b
+#define MSR_IA32_SPEC_CTRL              0x48
 #define MSR_IA32_TSCDEADLINE            0x6e0
 
 #define MSR_P6_PERFCTR0                 0xc1
@@ -888,6 +889,8 @@ typedef struct CPUX86State {
 
     uint64_t pat;
     uint32_t smbase;
+
+    uint64_t spec_ctrl;
 
     /* End of state preserved by INIT (dummy marker).  */
     struct {} end_init_save;

--- a/target-i386/cpu.h
+++ b/target-i386/cpu.h
@@ -410,6 +410,7 @@ typedef enum FeatureWord {
     FEAT_8000_0001_EDX, /* CPUID[8000_0001].EDX */
     FEAT_8000_0001_ECX, /* CPUID[8000_0001].ECX */
     FEAT_8000_0007_EDX, /* CPUID[8000_0007].EDX */
+    FEAT_8000_0008_EBX, /* CPUID[8000_0008].EBX */
     FEAT_C000_0001_EDX, /* CPUID[C000_0001].EDX */
     FEAT_KVM,           /* CPUID[4000_0001].EAX (KVM_CPUID_FEATURES) */
     FEAT_SVM,           /* CPUID[8000_000A].EDX */
@@ -576,6 +577,9 @@ typedef uint32_t FeatureWordArray[FEATURE_WORDS];
 
 #define CPUID_7_0_EDX_AVX512_4VNNIW (1U << 2) /* AVX512 Neural Network Instructions */
 #define CPUID_7_0_EDX_AVX512_4FMAPS (1U << 3) /* AVX512 Multiply Accumulation Single Precision */
+#define CPUID_7_0_EDX_SPEC_CTRL     (1U << 26) /* Indirect Branch - Restrict Speculation */
+
+#define CPUID_8000_0008_EBX_IBPB    (1U << 12) /* Indirect Branch Prediction Barrier */
 
 #define CPUID_XSAVE_XSAVEOPT   (1U << 0)
 #define CPUID_XSAVE_XSAVEC     (1U << 1)

--- a/target-i386/cpu.h
+++ b/target-i386/cpu.h
@@ -406,6 +406,7 @@ typedef enum FeatureWord {
     FEAT_1_EDX,         /* CPUID[1].EDX */
     FEAT_1_ECX,         /* CPUID[1].ECX */
     FEAT_7_0_EBX,       /* CPUID[EAX=7,ECX=0].EBX */
+    FEAT_7_0_EDX,       /* CPUID[EAX=7,ECX=0].EDX */
     FEAT_8000_0001_EDX, /* CPUID[8000_0001].EDX */
     FEAT_8000_0001_ECX, /* CPUID[8000_0001].ECX */
     FEAT_8000_0007_EDX, /* CPUID[8000_0007].EDX */
@@ -572,6 +573,9 @@ typedef uint32_t FeatureWordArray[FEATURE_WORDS];
 #define CPUID_7_0_EBX_AVX512PF (1U << 26) /* AVX-512 Prefetch */
 #define CPUID_7_0_EBX_AVX512ER (1U << 27) /* AVX-512 Exponential and Reciprocal */
 #define CPUID_7_0_EBX_AVX512CD (1U << 28) /* AVX-512 Conflict Detection */
+
+#define CPUID_7_0_EDX_AVX512_4VNNIW (1U << 2) /* AVX512 Neural Network Instructions */
+#define CPUID_7_0_EDX_AVX512_4FMAPS (1U << 3) /* AVX512 Multiply Accumulation Single Precision */
 
 #define CPUID_XSAVE_XSAVEOPT   (1U << 0)
 #define CPUID_XSAVE_XSAVEC     (1U << 1)

--- a/target-i386/machine.c
+++ b/target-i386/machine.c
@@ -743,6 +743,25 @@ static const VMStateDescription vmstate_xsave ={
     }
 };
 
+static bool spec_ctrl_needed(void *opaque)
+{
+    X86CPU *cpu = opaque;
+    CPUX86State *env = &cpu->env;
+
+    return env->spec_ctrl != 0;
+}
+
+static const VMStateDescription vmstate_spec_ctrl = {
+    .name = "cpu/spec_ctrl",
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .needed = spec_ctrl_needed,
+    .fields = (VMStateField[]){
+        VMSTATE_UINT64(env.spec_ctrl, X86CPU),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
 VMStateDescription vmstate_x86_cpu = {
     .name = "cpu",
     .version_id = 12,
@@ -861,6 +880,7 @@ VMStateDescription vmstate_x86_cpu = {
         &vmstate_msr_hyperv_time,
         &vmstate_avx512,
         &vmstate_xss,
+        &vmstate_spec_ctrl,
         &vmstate_xsave,
         NULL
     }


### PR DESCRIPTION
Base fixes without new CPU types definitions - `kvm-target-i386-cpu-add-new-CPU-models-for-indirect-bran.patch`.