### PR TITLE
Feature: block: preserve 'detect_zeroes' on image reopen

### DIFF
--- a/block.c
+++ b/block.c
@@ -2132,6 +2132,7 @@ static void bdrv_move_feature_fields(BlockDriverState *bs_dest,
     bs_dest->copy_on_read       = bs_src->copy_on_read;
 
     bs_dest->enable_write_cache = bs_src->enable_write_cache;
+    bs_dest->detect_zeroes      = bs_src->detect_zeroes;
 
     /* i/o throttled req */
     memcpy(&bs_dest->throttle_state,

--- a/blockdev.c
+++ b/blockdev.c
@@ -2623,6 +2623,10 @@ void qmp_drive_mirror(const char *device, const char *target,
         error_propagate(errp, local_err);
         goto out;
     }
+    if (unmap) {
+        // BDRV_O_UNMAP already inherited from source block driver state
+        target_bs->detect_zeroes = BLOCKDEV_DETECT_ZEROES_OPTIONS_UNMAP;
+    }
 
     bdrv_set_aio_context(target_bs, aio_context);
 


### PR DESCRIPTION
Signed-off-by: Mikhail Ushanov <MiUshanov@croc.ru>