### PR TITLE
Add ScaleIO support to qemu 2.12 (CentOS 7.7)

### DIFF
--- a/block/file-posix.c
+++ b/block/file-posix.c
@@ -994,6 +994,46 @@ static void raw_reopen_abort(BDRVReopenState *state)
     s->reopen_state = NULL;
 }
 
+#ifdef CONFIG_LINUX
+static int64_t get_sysfs_long(char *path)
+{
+    int ret;
+    int fd = -1;
+    char buf[32];
+    long value;
+    const char *end;
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        ret = -errno;
+        goto out;
+    }
+
+    do {
+        ret = read(fd, buf, sizeof(buf) - 1);
+    } while (ret == -1 && errno == EINTR);
+
+    if (ret < 0) {
+        ret = -errno;
+        goto out;
+    } else if (ret == 0) {
+        ret = -EIO;
+        goto out;
+    }
+    /* The file is ended with '\n', pass 'end' to accept that. */
+    ret = qemu_strtol(buf, &end, 10, &value);
+    if (ret == 0 && end && *end == '\n') {
+        ret = value;
+    }
+
+out:
+    if (fd != -1) {
+        close(fd);
+    }
+    return ret;
+}
+#endif
+
 static int hdev_get_max_transfer_length(BlockDriverState *bs, int fd)
 {
 #ifdef BLKSECTGET
@@ -1014,43 +1054,14 @@ static int hdev_get_max_transfer_length(BlockDriverState *bs, int fd)
 static int hdev_get_max_segments(const struct stat *st)
 {
 #ifdef CONFIG_LINUX
-    char buf[32];
-    const char *end;
     char *sysfspath;
-    int ret;
-    int fd = -1;
-    long max_segments;
 
     sysfspath = g_strdup_printf("/sys/dev/block/%u:%u/queue/max_segments",
                                 major(st->st_rdev), minor(st->st_rdev));
-    fd = open(sysfspath, O_RDONLY);
-    if (fd == -1) {
-        ret = -errno;
-        goto out;
-    }
-    do {
-        ret = read(fd, buf, sizeof(buf) - 1);
-    } while (ret == -1 && errno == EINTR);
-    if (ret < 0) {
-        ret = -errno;
-        goto out;
-    } else if (ret == 0) {
-        ret = -EIO;
-        goto out;
-    }
-    buf[ret] = 0;
-    /* The file is ended with '\n', pass 'end' to accept that. */
-    ret = qemu_strtol(buf, &end, 10, &max_segments);
-    if (ret == 0 && end && *end == '\n') {
-        ret = max_segments;
-    }
+    int64_t max_segments = get_sysfs_long(sysfspath);
 
-out:
-    if (fd != -1) {
-        close(fd);
-    }
     g_free(sysfspath);
-    return ret;
+    return max_segments;
 #else
     return -ENOTSUP;
 #endif

--- a/block/file-posix.c
+++ b/block/file-posix.c
@@ -3192,6 +3192,153 @@ static BlockDriver bdrv_host_device = {
 #endif
 };
 
+#ifdef CONFIG_SIO
+static int sio_probe_device(const char *filename)
+{
+    int priority = 0;
+    struct stat st;
+
+    if (stat(filename, &st) >= 0 && S_ISBLK(st.st_mode)) {
+        char resolved_path[PATH_MAX], *temp;
+
+        temp = realpath(filename, resolved_path);
+        if (temp && strstart(temp, "/dev/scini", NULL)) {
+            priority = 100;
+        }
+    }
+
+    return priority;
+}
+
+static int sio_open(BlockDriverState *bs, QDict *options, int flags,
+                    Error **errp)
+{
+    BDRVRawState *s = bs->opaque;
+    Error *local_err = NULL;
+    int ret;
+
+    ret = raw_open_common(bs, options, flags, 0, &local_err);
+    if (ret < 0) {
+        error_propagate(errp, local_err);
+        return ret;
+    }
+
+#ifdef BLKDISCARDZEROES
+    s->discard_zeroes = true;
+#endif
+    s->has_write_zeroes = true;
+
+    return ret;
+}
+
+static void sio_refresh_limits(BlockDriverState *bs, Error **errp)
+{
+    BDRVRawState *s = bs->opaque;
+    struct stat st;
+    char *sysfspath;
+
+    raw_refresh_limits(bs, errp);
+
+    if (!fstat(s->fd, &st)) {
+        sysfspath = g_strdup_printf("/sys/dev/block/%u:%u/queue/discard_granularity",
+                                    major(st.st_rdev), minor(st.st_rdev));
+        int64_t ret = get_sysfs_long(sysfspath);
+        if (ret > 0) {
+            bs->bl.pdiscard_alignment = ret;
+            bs->bl.pwrite_zeroes_alignment = ret;
+        }
+        g_free(sysfspath);
+    }
+}
+
+static int64_t sio_is_aligned(BlockDriverState *bs,
+    int64_t offset, int64_t bytes)
+{
+    int ret = 0;
+    int64_t pdiscard_alignment = bs->bl.pdiscard_alignment;
+
+    if (offset % pdiscard_alignment || bytes % pdiscard_alignment) {
+        ret = -ENOTSUP;
+    }
+    return ret;
+}
+
+static coroutine_fn int sio_co_pdiscard(BlockDriverState *bs,
+    int64_t offset, int bytes)
+{
+    BDRVRawState *s = bs->opaque;
+    int ret;
+
+    ret = sio_is_aligned(bs, offset, bytes);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = fd_open(bs);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return paio_submit_co(bs, s->fd, offset, NULL, bytes,
+                          QEMU_AIO_DISCARD | QEMU_AIO_BLKDEV);
+}
+
+static coroutine_fn int sio_co_pwrite_zeroes(BlockDriverState *bs,
+    int64_t offset, int bytes, BdrvRequestFlags flags)
+{
+    BDRVRawState *s = bs->opaque;
+
+    if (!!(flags & BDRV_REQ_MAY_UNMAP) && (s->discard_zeroes)) {
+        int ret = sio_is_aligned(bs, offset, bytes);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return hdev_co_pwrite_zeroes(bs, offset, bytes, flags);
+}
+
+static BlockDriver bdrv_sio_device = {
+    .format_name = "sio_device",
+    .protocol_name = "sio_device",
+    .instance_size = sizeof(BDRVRawState),
+    .bdrv_needs_filename = true,
+    .bdrv_probe_device = sio_probe_device,
+    .bdrv_parse_filename = hdev_parse_filename,
+    .bdrv_file_open = sio_open,
+    .bdrv_close = raw_close,
+    .bdrv_reopen_prepare = raw_reopen_prepare,
+    .bdrv_reopen_commit = raw_reopen_commit,
+    .bdrv_reopen_abort = raw_reopen_abort,
+    .bdrv_create = hdev_create,
+    .create_opts = &raw_create_opts,
+    .bdrv_co_pwrite_zeroes = sio_co_pwrite_zeroes,
+    .bdrv_co_pdiscard = sio_co_pdiscard,
+
+    .bdrv_co_preadv = raw_co_preadv,
+    .bdrv_co_pwritev = raw_co_pwritev,
+    .bdrv_aio_flush = raw_aio_flush,
+    .bdrv_refresh_limits = sio_refresh_limits,
+    .bdrv_io_plug = raw_aio_plug,
+    .bdrv_io_unplug = raw_aio_unplug,
+
+    .bdrv_truncate = raw_truncate,
+    .bdrv_getlength = raw_getlength,
+    .bdrv_get_info = raw_get_info,
+    .bdrv_get_allocated_file_size = raw_get_allocated_file_size,
+    .bdrv_check_perm = raw_check_perm,
+    .bdrv_set_perm = raw_set_perm,
+    .bdrv_abort_perm_update = raw_abort_perm_update,
+    .bdrv_probe_blocksizes = hdev_probe_blocksizes,
+    .bdrv_probe_geometry = hdev_probe_geometry,
+
+/* generic scsi device */
+#ifdef __linux__
+    .bdrv_aio_ioctl = hdev_aio_ioctl,
+#endif
+};
+#endif
+
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 static void cdrom_parse_filename(const char *filename, QDict *options,
                                  Error **errp)
@@ -3452,6 +3599,9 @@ static void bdrv_file_init(void)
 #endif
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
     bdrv_register(&bdrv_host_cdrom);
+#endif
+#ifdef CONFIG_SIO
+    bdrv_register(&bdrv_sio_device);
 #endif
 }
 

--- a/block/file-posix.c
+++ b/block/file-posix.c
@@ -3310,7 +3310,7 @@ static BlockDriver bdrv_sio_device = {
     .bdrv_reopen_prepare = raw_reopen_prepare,
     .bdrv_reopen_commit = raw_reopen_commit,
     .bdrv_reopen_abort = raw_reopen_abort,
-    .bdrv_create = hdev_create,
+    .bdrv_co_create_opts = hdev_co_create_opts,
     .create_opts = &raw_create_opts,
     .bdrv_co_pwrite_zeroes = sio_co_pwrite_zeroes,
     .bdrv_co_pdiscard = sio_co_pdiscard,
@@ -3322,7 +3322,7 @@ static BlockDriver bdrv_sio_device = {
     .bdrv_io_plug = raw_aio_plug,
     .bdrv_io_unplug = raw_aio_unplug,
 
-    .bdrv_truncate = raw_truncate,
+    .bdrv_co_truncate = raw_co_truncate,
     .bdrv_getlength = raw_getlength,
     .bdrv_get_info = raw_get_info,
     .bdrv_get_allocated_file_size = raw_get_allocated_file_size,

--- a/block/file-posix.c
+++ b/block/file-posix.c
@@ -487,7 +487,7 @@ static int raw_open_common(BlockDriverState *bs, QDict *options,
 
     locking = qapi_enum_parse(&OnOffAuto_lookup,
                               qemu_opt_get(opts, "locking"),
-                              ON_OFF_AUTO_AUTO, &local_err);
+                              ON_OFF_AUTO_OFF, &local_err);
     if (local_err) {
         error_propagate(errp, local_err);
         ret = -EINVAL;

--- a/block/file-posix.c
+++ b/block/file-posix.c
@@ -3217,7 +3217,7 @@ static int sio_open(BlockDriverState *bs, QDict *options, int flags,
     Error *local_err = NULL;
     int ret;
 
-    ret = raw_open_common(bs, options, flags, 0, &local_err);
+    ret = raw_open_common(bs, options, flags, 0, true, &local_err);
     if (ret < 0) {
         error_propagate(errp, local_err);
         return ret;

--- a/blockdev.c
+++ b/blockdev.c
@@ -3893,6 +3893,11 @@ static void blockdev_mirror_common(const char *job_id, BlockDriverState *bs,
         sync = MIRROR_SYNC_MODE_FULL;
     }
 
+    if (unmap) {
+        // BDRV_O_UNMAP already inherited from source block driver state
+        target->detect_zeroes = BLOCKDEV_DETECT_ZEROES_OPTIONS_UNMAP;
+    }
+
     /* pass the node name to replace to mirror start since it's loose coupling
      * and will allow to check whether the node still exist at mirror completion
      */

--- a/build_configure.sh
+++ b/build_configure.sh
@@ -125,6 +125,7 @@ fi
     --enable-werror \
     --disable-xen \
     --disable-xfsctl \
+    --enable-sio \
     --enable-gnutls \
     --enable-gcrypt \
     --disable-nettle \
@@ -176,7 +177,7 @@ fi
     --enable-capstone \
     --audio-drv-list= \
     --enable-git-update \
-    --block-drv-rw-whitelist=qcow2,raw,file,host_device,nbd,iscsi,${gluster_driver}${rbd_driver}${vxhs_driver}blkdebug,luks,null-co,nvme,copy-on-read,throttle \
+    --block-drv-rw-whitelist=qcow2,raw,file,host_device,sio_device,nbd,iscsi,${gluster_driver}${rbd_driver}${vxhs_driver}blkdebug,luks,null-co,nvme,copy-on-read,throttle \
     --block-drv-ro-whitelist=vmdk,vhdx,vpc,https,ssh \
     --rhel-target=${rhel_target} \
     "$@"

--- a/configure
+++ b/configure
@@ -341,6 +341,7 @@ cap_ng=""
 attr=""
 libattr=""
 xfs=""
+sio=""
 tcg="yes"
 membarrier=""
 vhost_net="no"
@@ -1221,6 +1222,10 @@ for opt do
   ;;
   --enable-xfsctl) xfs="yes"
   ;;
+  --disable-sio) sio="no"
+  ;;
+  --enable-sio) sio="yes"
+  ;;
   --disable-smartcard) smartcard="no"
   ;;
   --enable-smartcard) smartcard="yes"
@@ -1646,6 +1651,7 @@ disabled with --disable-FEATURE, default is enabled if available:
   opengl          opengl support
   virglrenderer   virgl rendering support
   xfsctl          xfsctl support
+  sio             ScaleIO support
   qom-cast-debug  cast debugging support
   tools           build qemu-io, qemu-nbd and qemu-image tools
   vxhs            Veritas HyperScale vDisk backend support
@@ -5858,6 +5864,7 @@ fi
 echo "spice support     $spice $(echo_version $spice $spice_protocol_version/$spice_server_version)"
 echo "rbd support       $rbd"
 echo "xfsctl support    $xfs"
+echo "ScaleIO support   $sio"
 echo "smartcard support $smartcard"
 echo "libusb            $libusb"
 echo "usb net redir     $usb_redir"
@@ -6095,6 +6102,9 @@ if test "$fnmatch" = "yes" ; then
 fi
 if test "$xfs" = "yes" ; then
   echo "CONFIG_XFS=y" >> $config_host_mak
+fi
+if test "$sio" = "yes" ; then
+  echo "CONFIG_SIO=y" >> $config_host_mak
 fi
 qemu_version=$(head $source_path/VERSION)
 echo "VERSION=$qemu_version" >>$config_host_mak

--- a/qapi/block-core.json
+++ b/qapi/block-core.json
@@ -4273,6 +4273,7 @@
       'rbd':            'BlockdevCreateOptionsRbd',
       'replication':    'BlockdevCreateNotSupported',
       'sheepdog':       'BlockdevCreateOptionsSheepdog',
+      'sio_device':     'BlockdevCreateNotSupported',
       'ssh':            'BlockdevCreateOptionsSsh',
       'throttle':       'BlockdevCreateNotSupported',
       'vdi':            'BlockdevCreateOptionsVdi',

--- a/qapi/block-core.json
+++ b/qapi/block-core.json
@@ -275,7 +275,7 @@
 #       0.14.0 this can be: 'blkdebug', 'bochs', 'cloop', 'cow', 'dmg',
 #       'file', 'file', 'ftp', 'ftps', 'host_cdrom', 'host_device',
 #       'http', 'https', 'luks', 'nbd', 'parallels', 'qcow',
-#       'qcow2', 'raw', 'vdi', 'vmdk', 'vpc', 'vvfat'
+#       'qcow2', 'raw', 'sio_device', 'vdi', 'vmdk', 'vpc', 'vvfat'
 #       2.2: 'archipelago' added, 'cow' dropped
 #       2.3: 'host_floppy' deprecated
 #       2.5: 'host_floppy' dropped
@@ -2674,8 +2674,8 @@
             'dmg', 'file', 'ftp', 'ftps', 'gluster', 'host_cdrom',
             'host_device', 'http', 'https', 'iscsi', 'luks', 'nbd', 'nfs',
             'null-aio', 'null-co', 'nvme', 'parallels', 'qcow', 'qcow2', 'qed',
-            'quorum', 'raw', 'rbd', 'replication', 'sheepdog', 'ssh',
-            'throttle', 'vdi', 'vhdx', 'vmdk', 'vpc', 'vvfat', 'vxhs' ] }
+            'quorum', 'raw', 'rbd', 'replication', 'sheepdog', 'sio_device',
+            'ssh', 'throttle', 'vdi', 'vhdx', 'vmdk', 'vpc', 'vvfat', 'vxhs' ] }
 
 ##
 # @BlockdevOptionsFile:
@@ -3744,6 +3744,7 @@
       'rbd':        'BlockdevOptionsRbd',
       'replication':'BlockdevOptionsReplication',
       'sheepdog':   'BlockdevOptionsSheepdog',
+      'sio_device': 'BlockdevOptionsFile',
       'ssh':        'BlockdevOptionsSsh',
       'throttle':   'BlockdevOptionsThrottle',
       'vdi':        'BlockdevOptionsGenericFormat',

--- a/qemu-kvm.spec
+++ b/qemu-kvm.spec
@@ -59,7 +59,7 @@
 
 #Versions of various parts:
 
-%define buildid %{nil}
+%define buildid .CROC1
 %define pkgname qemu-kvm
 %define rhel_ma_suffix -ma
 %define rhel_suffix -rhel
@@ -1863,6 +1863,20 @@ Patch849: kvm-vl-Fix-drive-blockdev-persistent-reservation-managem.patch
 # For bz#1608226 - [virtual-network][mq] prompt warning "qemu-kvm: unable to start vhost net: 14: falling back on userspace virtio" when boot with win8+ guests with multi-queue
 Patch850: kvm-vhost_net-don-t-set-backend-for-the-uninitialized-vi.patch
 
+# CROC patches and backports
+# ScaleIO driver feature
+Patch9000: 9000-configure-added-CONFIG_SIO-option.patch
+# ScaleIO driver feature
+Patch9001: 9001-fileposix-reuse-sysfs-getter-functiion.patch
+# ScaleIO driver feature
+Patch9002: 9002-fileposix-add-scaleio-driver-implementation.patch
+# ScaleIO driver feature
+Patch9003: 9003-qapi-add-scaleio-device-format.patch
+# Disable file locking
+Patch9004: 9004-fileposix-disable-file-locking-by-default.patch
+# Enable 'detect_zeroes' in drive_mirror
+Patch9005: 9005-blockdev-enable-detect_zeroes-on-target-bs-in-drive_.patch
+
 BuildRequires: zlib-devel
 BuildRequires: glib2-devel
 BuildRequires: which
@@ -2936,6 +2950,14 @@ chmod 755 $(ls tests/qemu-iotests/???)
 
 ApplyOptionalPatch qemu-kvm-test.patch
 
+# CROC patches and backports
+%patch9000 -p1
+%patch9001 -p1
+%patch9002 -p1
+%patch9003 -p1
+%patch9004 -p1
+%patch9005 -p1
+
 # for tscdeadline_latency.flat
 %ifarch x86_64
   tar -xf %{SOURCE25}
@@ -3464,6 +3486,14 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 %endif
 
 %changelog
+* Thu Oct 31 2019 Vladislav Odintsov <odivlad@gmail.com> - ev-2.12.0-33.1.el7_7.CROC1
+- 9000-configure-added-CONFIG_SIO-option.patch
+- 9001-fileposix-reuse-sysfs-getter-functiion.patch
+- 9002-fileposix-add-scaleio-driver-implementation.patch
+- 9003-qapi-add-scaleio-device-format.patch
+- 9004-fileposix-disable-file-locking-by-default.patch
+- 9005-blockdev-enable-detect_zeroes-on-target-bs-in-drive_.patch
+
 * Fri Aug 23 2019 Sandro Bonazzola <sbonazzo@redhat.com> - ev-2.12.0-33.1.el7
 - Removing RH branding from package name
 

--- a/qemu-kvm.spec
+++ b/qemu-kvm.spec
@@ -59,6 +59,7 @@
 
 #Versions of various parts:
 
+%define buildid %{nil}
 %define pkgname qemu-kvm
 %define rhel_ma_suffix -ma
 %define rhel_suffix -rhel
@@ -113,7 +114,7 @@ Obsoletes: %1%{rhev_provide_suffix} < %{epoch}:%{version}-%{release}   \
 Summary: QEMU is a machine emulator and virtualizer
 Name: %{pkgname}%{?pkgsuffix}
 Version: 2.12.0
-Release: 33.1%{?dist}
+Release: 33.1%{?dist}%{buildid}
 # Epoch because we pushed a qemu-1.0 package. AIUI this can't ever be dropped
 Epoch: 10
 License: GPLv2 and GPLv2+ and CC-BY


### PR DESCRIPTION
This patch adds support for EMC ScaleIO to updated QEMU (2.12) from CentOS 7.7 official repos.